### PR TITLE
Add integration field ref header if available from /api

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,11 @@ export function PrismicLink({uri, accessToken}) {
       (request, options) => {
         return prismicClient.getApi().then((api) => {
           const authorizationHeader = accessToken ? { Authorization: `Token ${accessToken}` } : {};
+          const integrationFieldRef = api.integrationFieldRef ? { 'Prismic-integration-field-ref' : api.integrationFieldRef } : {};
           return {
             headers: {
               'Prismic-ref': api.masterRef.ref,
+              ...integrationFieldRef,
               ...options.headers,
               ...authorizationHeader
             }


### PR DESCRIPTION
We've added the header to be used in the cdn cache key