### PR TITLE
Polyfill spread operator in Edge and IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
       }
     ],
     "minify"
-  ]
+  ],
+  "plugins": ["@babel/plugin-proposal-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
   "devDependencies": {
     "@babel/cli": "^7.1.0",
     "@babel/core": "^7.1.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
     "@babel/preset-env": "^7.1.0",
+    "@rollup/plugin-babel": "^5.0.3",
     "babel-preset-minify": "^0.4.3",
     "fetch-mock": "^8.0.0",
     "graphql-tag": "^2.10.1",
     "jest": "^24.9.0",
     "rollup": "^1.27.5",
-    "rollup-plugin-babel-minify": "^9.1.1"
+    "rollup-plugin-terser": "^6.1.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
-import minify from 'rollup-plugin-babel-minify';
+import babel from '@rollup/plugin-babel';
+import { terser } from "rollup-plugin-terser";
 
 const options = {
   input: './src/index.js',
@@ -7,11 +8,8 @@ const options = {
     file: './dist/apollo-link-prismic.min.js',
   },
   plugins: [
-    minify({
-      // Options for babel-minify.
-      sourceMap: false,
-      comments: false,
-    })
+    babel({ babelHelpers: 'bundled' }),
+    terser()
   ],
 };
 


### PR DESCRIPTION
This pull request fixes issue #14 by adding `@babel/plugin-proposal-object-rest-spread`.

It also switches to `rollup-plugin-terser` from `rollup-plugin-babel-minify`, as the latter plugin is now deprecated.