### PR TITLE
fix: cache-bust requests using `@prismicio/client`'s updated `graphQLFetch()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/client": "^6.3.0"
+				"@prismicio/client": "^6.4.1-alpha.1"
 			},
 			"devDependencies": {
 				"@apollo/client": "^3.5.8",
@@ -667,9 +667,9 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.3.0.tgz",
-			"integrity": "sha512-FeKbmuXNCNU1tw+yvc87PfYF8wSY0rfe0Ou2VCo0PFdMlHzRMu8CXkITNswv3cDakeu8xU0Z7IOfTiF4WE5nLQ==",
+			"version": "6.4.1-alpha.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.4.1-alpha.1.tgz",
+			"integrity": "sha512-u8lTp1f/kSfhB2tIA0HhCQr+eNDLkHwPbc7dBj1dBPSl/la8JmBylhK56zTGm1Ay7do43doZSpcb/eJq8VniJQ==",
 			"dependencies": {
 				"@prismicio/helpers": "^2.1.1",
 				"@prismicio/types": "^0.1.24"
@@ -8965,9 +8965,9 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.3.0.tgz",
-			"integrity": "sha512-FeKbmuXNCNU1tw+yvc87PfYF8wSY0rfe0Ou2VCo0PFdMlHzRMu8CXkITNswv3cDakeu8xU0Z7IOfTiF4WE5nLQ==",
+			"version": "6.4.1-alpha.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.4.1-alpha.1.tgz",
+			"integrity": "sha512-u8lTp1f/kSfhB2tIA0HhCQr+eNDLkHwPbc7dBj1dBPSl/la8JmBylhK56zTGm1Ay7do43doZSpcb/eJq8VniJQ==",
 			"requires": {
 				"@prismicio/helpers": "^2.1.1",
 				"@prismicio/types": "^0.1.24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/client": "^6.4.1-alpha.1"
+				"@prismicio/client": "^6.4.1"
 			},
 			"devDependencies": {
 				"@apollo/client": "^3.5.8",
@@ -667,9 +667,9 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "6.4.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.4.1-alpha.1.tgz",
-			"integrity": "sha512-u8lTp1f/kSfhB2tIA0HhCQr+eNDLkHwPbc7dBj1dBPSl/la8JmBylhK56zTGm1Ay7do43doZSpcb/eJq8VniJQ==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.4.1.tgz",
+			"integrity": "sha512-yP3aTETsybx7DOMeOTDYMJgZyGBBwu5HpDqcPtZ4QUhKWjy749ZNVUMfXayU90609UhzEvKSkGtu13u0wcpbDw==",
 			"dependencies": {
 				"@prismicio/helpers": "^2.1.1",
 				"@prismicio/types": "^0.1.24"
@@ -8965,9 +8965,9 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "6.4.1-alpha.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.4.1-alpha.1.tgz",
-			"integrity": "sha512-u8lTp1f/kSfhB2tIA0HhCQr+eNDLkHwPbc7dBj1dBPSl/la8JmBylhK56zTGm1Ay7do43doZSpcb/eJq8VniJQ==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.4.1.tgz",
+			"integrity": "sha512-yP3aTETsybx7DOMeOTDYMJgZyGBBwu5HpDqcPtZ4QUhKWjy749ZNVUMfXayU90609UhzEvKSkGtu13u0wcpbDw==",
 			"requires": {
 				"@prismicio/helpers": "^2.1.1",
 				"@prismicio/types": "^0.1.24"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"unit": "nyc --reporter=lcovonly --reporter=text --exclude-after-remap=false ava"
 	},
 	"dependencies": {
-		"@prismicio/client": "^6.4.1-alpha.1"
+		"@prismicio/client": "^6.4.1"
 	},
 	"devDependencies": {
 		"@apollo/client": "^3.5.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"unit": "nyc --reporter=lcovonly --reporter=text --exclude-after-remap=false ava"
 	},
 	"dependencies": {
-		"@prismicio/client": "^6.3.0"
+		"@prismicio/client": "^6.4.1-alpha.1"
 	},
 	"devDependencies": {
 		"@apollo/client": "^3.5.8",

--- a/src/createPrismicLink.ts
+++ b/src/createPrismicLink.ts
@@ -121,7 +121,7 @@ export const createPrismicLink = (config: PrismicLinkConfig): ApolloLink => {
 
 	return createHttpLink({
 		uri,
-		fetch: client.graphqlFetch,
+		fetch: client.graphQLFetch,
 		useGETForQueries: true,
 		...options,
 	});

--- a/test/createPrismicLink.test.ts
+++ b/test/createPrismicLink.test.ts
@@ -48,6 +48,7 @@ const repositoryResponse: Partial<prismicT.Repository> = {
 		},
 	],
 };
+const ref = repositoryResponse.refs?.[0].ref as string;
 
 test("creates an HTTP Link from a repositoryName", async (t) => {
 	const repositoryName = "qwerty";
@@ -68,6 +69,7 @@ test("creates an HTTP Link from a repositoryName", async (t) => {
 			return new Response(JSON.stringify(repositoryResponse));
 		} else if (`${instance.origin}${instance.pathname}` === uri) {
 			t.is(instance.searchParams.get("query"), compressedQuery);
+			t.is(instance.searchParams.get("ref"), ref);
 
 			return new Response(
 				JSON.stringify({
@@ -88,7 +90,7 @@ test("creates an HTTP Link from a repositoryName", async (t) => {
 
 	await executeRequest(link, { query });
 
-	t.plan(1);
+	t.plan(2);
 });
 
 test("supports only a uri option", async (t) => {
@@ -110,6 +112,7 @@ test("supports only a uri option", async (t) => {
 			return new Response(JSON.stringify(repositoryResponse));
 		} else if (`${instance.origin}${instance.pathname}` === uri) {
 			t.is(instance.searchParams.get("query"), compressedQuery);
+			t.is(instance.searchParams.get("ref"), ref);
 
 			return new Response(
 				JSON.stringify({
@@ -130,7 +133,7 @@ test("supports only a uri option", async (t) => {
 
 	await executeRequest(link, { query });
 
-	t.plan(1);
+	t.plan(2);
 });
 
 test("throws if neither a repositoryName or uri option is given", (t) => {
@@ -169,6 +172,7 @@ test("supports custom API endpoint (for Rest API)", async (t) => {
 			return new Response(JSON.stringify(repositoryResponse));
 		} else if (`${instance.origin}${instance.pathname}` === uri) {
 			t.is(instance.searchParams.get("query"), compressedQuery);
+			t.is(instance.searchParams.get("ref"), ref);
 
 			return new Response(
 				JSON.stringify({
@@ -190,7 +194,7 @@ test("supports custom API endpoint (for Rest API)", async (t) => {
 
 	await executeRequest(link, { query });
 
-	t.plan(1);
+	t.plan(2);
 });
 
 test("supports custom GraphQL endpoint", async (t) => {
@@ -212,6 +216,7 @@ test("supports custom GraphQL endpoint", async (t) => {
 			return new Response(JSON.stringify(repositoryResponse));
 		} else if (`${instance.origin}${instance.pathname}` === uri) {
 			t.is(instance.searchParams.get("query"), compressedQuery);
+			t.is(instance.searchParams.get("ref"), ref);
 
 			return new Response(
 				JSON.stringify({
@@ -233,5 +238,5 @@ test("supports custom GraphQL endpoint", async (t) => {
 
 	await executeRequest(link, { query });
 
-	t.plan(1);
+	t.plan(2);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR forces GraphQL requests to be cache-busted. It does this using `@prismicio/client`'s updated `graphQLFetch()` method. The updated method includes the requests's `ref` in the URL parameter.

For more details on the cache-busting strategy, see https://github.com/prismicio/prismic-client/pull/227.

Fixes: #39

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐧
