### PR TITLE
refactor: update to `@apollo/client` v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@prismicio/client": "^7.0.1"
 			},
 			"devDependencies": {
-				"@apollo/client": "^3.5.8",
+				"@apollo/client": "^4.0.0",
 				"@size-limit/preset-small-lib": "^7.0.8",
 				"@types/node-fetch": "^2.6.0",
 				"@types/sinon": "^10.0.11",
@@ -39,7 +39,7 @@
 				"node": ">=12.7.0"
 			},
 			"peerDependencies": {
-				"@apollo/client": "^3"
+				"@apollo/client": "^4"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -55,31 +55,41 @@
 			}
 		},
 		"node_modules/@apollo/client": {
-			"version": "3.5.8",
-			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.8.tgz",
-			"integrity": "sha512-MAm05+I1ullr64VLpZwon/ISnkMuNLf6vDqgo9wiMhHYBGT4yOAbAIseRdjCHZwfSx/7AUuBgaTNOssZPIr6FQ==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.4.tgz",
+			"integrity": "sha512-3+fTQUA3AdC08urPF7si0ptLiAaVOH5R/3drwXzic8yqzTL4W3ME6klLj/EpgMND0FbWD7sM8TCkEDoe4OckMw==",
 			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"dist",
+				"codegen",
+				"scripts/codemods/ac3-to-ac4"
+			],
 			"dependencies": {
-				"@graphql-typed-document-node/core": "^3.0.0",
-				"@wry/context": "^0.6.0",
-				"@wry/equality": "^0.5.0",
-				"@wry/trie": "^0.3.0",
-				"graphql-tag": "^2.12.3",
-				"hoist-non-react-statics": "^3.3.2",
-				"optimism": "^0.16.1",
-				"prop-types": "^15.7.2",
-				"symbol-observable": "^4.0.0",
-				"ts-invariant": "^0.9.4",
-				"tslib": "^2.3.0",
-				"zen-observable-ts": "^1.2.0"
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"@wry/caches": "^1.0.0",
+				"@wry/equality": "^0.5.6",
+				"@wry/trie": "^0.5.0",
+				"graphql-tag": "^2.12.6",
+				"optimism": "^0.18.0",
+				"tslib": "^2.3.0"
 			},
 			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-				"react": "^16.8.0 || ^17.0.0",
+				"graphql": "^16.0.0",
+				"graphql-ws": "^5.5.5 || ^6.0.3",
+				"react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"rxjs": "^7.3.0",
 				"subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
 			},
 			"peerDependenciesMeta": {
+				"graphql-ws": {
+					"optional": true
+				},
 				"react": {
+					"optional": true
+				},
+				"react-dom": {
 					"optional": true
 				},
 				"subscriptions-transport-ws": {
@@ -1158,11 +1168,25 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@wry/context": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-			"integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+		"node_modules/@wry/caches": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+			"integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@wry/context": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+			"integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -1171,10 +1195,11 @@
 			}
 		},
 		"node_modules/@wry/equality": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
-			"integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+			"integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -1183,10 +1208,11 @@
 			}
 		},
 		"node_modules/@wry/trie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
-			"integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+			"integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.3.0"
 			},
@@ -4062,15 +4088,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/hoist-non-react-statics": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"dev": true,
-			"dependencies": {
-				"react-is": "^16.7.0"
-			}
-		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -4852,18 +4869,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
-			}
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -5962,15 +5967,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6005,13 +6001,16 @@
 			}
 		},
 		"node_modules/optimism": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-			"integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+			"integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@wry/context": "^0.6.0",
-				"@wry/trie": "^0.3.0"
+				"@wry/caches": "^1.0.0",
+				"@wry/context": "^0.7.0",
+				"@wry/trie": "^0.5.0",
+				"tslib": "^2.3.0"
 			}
 		},
 		"node_modules/optionator": {
@@ -6480,17 +6479,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/prop-types": {
-			"version": "15.8.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
-			"dependencies": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.13.1"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6538,12 +6526,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
 		},
 		"node_modules/read-pkg": {
 			"version": "3.0.0",
@@ -6968,6 +6950,17 @@
 			],
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -7822,15 +7815,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/symbol-observable": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-			"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/temp-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -7954,18 +7938,6 @@
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
-			}
-		},
-		"node_modules/ts-invariant": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
-			"integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/tslib": {
@@ -8442,21 +8414,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/zen-observable": {
-			"version": "0.8.15",
-			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-			"dev": true
-		},
-		"node_modules/zen-observable-ts": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
-			"integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
-			"dev": true,
-			"dependencies": {
-				"zen-observable": "0.8.15"
-			}
 		}
 	},
 	"dependencies": {
@@ -8470,23 +8427,18 @@
 			}
 		},
 		"@apollo/client": {
-			"version": "3.5.8",
-			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.8.tgz",
-			"integrity": "sha512-MAm05+I1ullr64VLpZwon/ISnkMuNLf6vDqgo9wiMhHYBGT4yOAbAIseRdjCHZwfSx/7AUuBgaTNOssZPIr6FQ==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.4.tgz",
+			"integrity": "sha512-3+fTQUA3AdC08urPF7si0ptLiAaVOH5R/3drwXzic8yqzTL4W3ME6klLj/EpgMND0FbWD7sM8TCkEDoe4OckMw==",
 			"dev": true,
 			"requires": {
-				"@graphql-typed-document-node/core": "^3.0.0",
-				"@wry/context": "^0.6.0",
-				"@wry/equality": "^0.5.0",
-				"@wry/trie": "^0.3.0",
-				"graphql-tag": "^2.12.3",
-				"hoist-non-react-statics": "^3.3.2",
-				"optimism": "^0.16.1",
-				"prop-types": "^15.7.2",
-				"symbol-observable": "^4.0.0",
-				"ts-invariant": "^0.9.4",
-				"tslib": "^2.3.0",
-				"zen-observable-ts": "^1.2.0"
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"@wry/caches": "^1.0.0",
+				"@wry/equality": "^0.5.6",
+				"@wry/trie": "^0.5.0",
+				"graphql-tag": "^2.12.6",
+				"optimism": "^0.18.0",
+				"tslib": "^2.3.0"
 			}
 		},
 		"@babel/code-frame": {
@@ -9296,28 +9248,37 @@
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
+		"@wry/caches": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+			"integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
 		"@wry/context": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-			"integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+			"integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.3.0"
 			}
 		},
 		"@wry/equality": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
-			"integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+			"integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.3.0"
 			}
 		},
 		"@wry/trie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
-			"integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+			"integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.3.0"
@@ -11370,15 +11331,6 @@
 				}
 			}
 		},
-		"hoist-non-react-statics": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"dev": true,
-			"requires": {
-				"react-is": "^16.7.0"
-			}
-		},
 		"hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -11971,15 +11923,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -12756,12 +12699,6 @@
 				}
 			}
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12789,13 +12726,15 @@
 			}
 		},
 		"optimism": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-			"integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+			"integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
 			"dev": true,
 			"requires": {
-				"@wry/context": "^0.6.0",
-				"@wry/trie": "^0.3.0"
+				"@wry/caches": "^1.0.0",
+				"@wry/context": "^0.7.0",
+				"@wry/trie": "^0.5.0",
+				"tslib": "^2.3.0"
 			}
 		},
 		"optionator": {
@@ -13120,17 +13059,6 @@
 				"fromentries": "^1.2.0"
 			}
 		},
-		"prop-types": {
-			"version": "15.8.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.13.1"
-			}
-		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -13153,12 +13081,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-			"dev": true
-		},
-		"react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
 		},
 		"read-pkg": {
@@ -13464,6 +13386,16 @@
 			"dev": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"safe-buffer": {
@@ -14110,12 +14042,6 @@
 				"has-flag": "^4.0.0"
 			}
 		},
-		"symbol-observable": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-			"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-			"dev": true
-		},
 		"temp-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -14209,15 +14135,6 @@
 					"integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
 					"dev": true
 				}
-			}
-		},
-		"ts-invariant": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
-			"integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
-			"dev": true,
-			"requires": {
-				"tslib": "^2.1.0"
 			}
 		},
 		"tslib": {
@@ -14582,21 +14499,6 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
 			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
 			"dev": true
-		},
-		"zen-observable": {
-			"version": "0.8.15",
-			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-			"dev": true
-		},
-		"zen-observable-ts": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
-			"integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
-			"dev": true,
-			"requires": {
-				"zen-observable": "0.8.15"
-			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@prismicio/client": "^7.0.1"
 	},
 	"devDependencies": {
-		"@apollo/client": "^3.5.8",
+		"@apollo/client": "^4.0.0",
 		"@size-limit/preset-small-lib": "^7.0.8",
 		"@types/node-fetch": "^2.6.0",
 		"@types/sinon": "^10.0.11",
@@ -75,7 +75,7 @@
 		"typescript": "^4.5.5"
 	},
 	"peerDependencies": {
-		"@apollo/client": "^3"
+		"@apollo/client": "^4"
 	},
 	"engines": {
 		"node": ">=12.7.0"

--- a/src/createPrismicLink.ts
+++ b/src/createPrismicLink.ts
@@ -1,5 +1,5 @@
-import type { ApolloLink, HttpOptions } from "@apollo/client/core";
-import { createHttpLink } from "@apollo/client/core";
+import type { ApolloLink } from "@apollo/client/core";
+import { HttpLink } from "@apollo/client/link/http";
 import {
 	FetchLike,
 	getRepositoryName,
@@ -12,7 +12,7 @@ import {
  * Configuration for `createPrismicLink`.
  */
 export type PrismicLinkConfig = Omit<
-	HttpOptions,
+	HttpLink.Options,
 	"fetch" | "useGETForQueries"
 > &
 	(
@@ -120,7 +120,7 @@ export const createPrismicLink = (config: PrismicLinkConfig): ApolloLink => {
 		accessToken,
 	});
 
-	return createHttpLink({
+	return new HttpLink({
 		uri,
 		fetch: client.graphQLFetch,
 		useGETForQueries: true,

--- a/test/createPrismicLink.test.ts
+++ b/test/createPrismicLink.test.ts
@@ -1,10 +1,10 @@
 import test from "ava";
 import {
+	ApolloClient,
 	ApolloLink,
 	execute,
-	FetchResult,
 	gql,
-	GraphQLRequest,
+	InMemoryCache,
 } from "@apollo/client/core";
 import { Response } from "node-fetch";
 import * as sinon from "sinon";
@@ -14,27 +14,31 @@ import * as prismicT from "@prismicio/types";
 import { createPrismicLink } from "../src";
 
 interface LinkResult<T> {
-	result: FetchResult<T>;
+	result: ApolloLink.Result<T>;
 }
 
 const executeRequest = <T = unknown>(
 	link: ApolloLink,
-	request: GraphQLRequest,
+	request: ApolloLink.Request,
 ) => {
 	const linkResult = {} as LinkResult<T>;
+	const client = new ApolloClient({
+		cache: new InMemoryCache(),
+		link: ApolloLink.empty(),
+	});
 
 	return new Promise<LinkResult<T>>((resolve, reject) => {
-		execute(link, request).subscribe(
-			(result) => {
-				linkResult.result = result as FetchResult<T>;
+		execute(link, request, { client }).subscribe({
+			next: (result) => {
+				linkResult.result = result as ApolloLink.Result<T>;
 			},
-			(error) => {
+			error: (error) => {
 				reject(error);
 			},
-			() => {
+			complete: () => {
 				resolve(linkResult);
 			},
-		);
+		});
 	});
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Update Apollo client to 4.0

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

The link's signature and functionality remain the same, but this requires Apollo 4.0 as a peer dependency, which will introduce numerous breaking changes.

## Description

- Migrated fully to the new Apollo 4.0 changes. Some changes, such as function-based link creation, would still be available, but they have now been deprecated. I don't know whether you would like to try to maintain support for older Apollo client versions as well.
- Updated to class-based link and migrated deprecated types.
- Fixed test setup by introducing the context needed for execution and migrating from deprecated types.
## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
