### PR TITLE
fix: update @prismicio/client and graphql dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "1.1.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/client": "^7.0.1"
+				"@prismicio/client": "^7.21.7"
 			},
 			"devDependencies": {
 				"@apollo/client": "^3.5.8",
 				"@types/node": "^25.5.2",
 				"@vitest/coverage-v8": "^4.1.2",
-				"graphql": "^16.3.0",
+				"graphql": "^16.13.2",
 				"oxfmt": "^0.43.0",
 				"oxlint": "^1.58.0",
 				"tsdown": "^0.21.7",

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
 		"test": "npm run lint && npm run types && npm run unit && npm run build"
 	},
 	"dependencies": {
-		"@prismicio/client": "^7.0.1"
+		"@prismicio/client": "^7.21.7"
 	},
 	"devDependencies": {
 		"@apollo/client": "^3.5.8",
 		"@types/node": "^25.5.2",
 		"@vitest/coverage-v8": "^4.1.2",
-		"graphql": "^16.3.0",
+		"graphql": "^16.13.2",
 		"oxfmt": "^0.43.0",
 		"oxlint": "^1.58.0",
 		"tsdown": "^0.21.7",


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Update dependency versions to their latest compatible releases:

- `@prismicio/client`: ^7.0.1 → ^7.21.7
- `graphql` (dev): ^16.3.0 → ^16.13.2

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only update; main risk is subtle runtime/type behavior changes from the `@prismicio/client` version bump that could affect link behavior if upstream APIs changed.
> 
> **Overview**
> Updates dependencies to newer compatible releases: bumps runtime `@prismicio/client` from `^7.0.1` to `^7.21.7` and dev `graphql` from `^16.3.0` to `^16.13.2`, with corresponding `package-lock.json` updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff61e40e7f6e8db1ed6d545ca42ac1eafaadbba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->